### PR TITLE
Shortcircuit kill_manager for grad civs

### DIFF
--- a/Missionframework/scripts/shared/kill_manager.sqf
+++ b/Missionframework/scripts/shared/kill_manager.sqf
@@ -6,7 +6,7 @@ if (isServer) then {
 
     // Get Killer, when ACE enabled, via lastDamageSource
     if (KP_liberation_ace) then {
-        if (local _unit) then {
+        if (!KPLIB_use_liberation_civilians || local _unit) then {
             _killer = _unit getVariable ["ace_medical_lastDamageSource", _killer];
             if (KP_liberation_kill_debug > 0) then {["_unit is local to server", "KILL"] call KPLIB_fnc_log;};
         } else {


### PR DESCRIPTION
One more bugfix since my tests were done locally and I didn't discover this.

If GRAD Civs is used, the `kill_manager` should retrieve the killer via the `ace_medical_lastDamageSource` variable.

GRAD Civs already does this and passes it as the `_killer`, but this is a quick fix.