### PR TITLE
Bugfixes for Arsenal and Build system

### DIFF
--- a/Missionframework/modules/arsenal/CfgFunctions.hpp
+++ b/Missionframework/modules/arsenal/CfgFunctions.hpp
@@ -2,7 +2,7 @@
     File: CfgFunctions.hpp
     Author: ColinM - https://github.com/ColinM9991/KP-Liberation
     Date: 2022-08-06
-    Last Update: 2022-08-09
+    Last Update: 2022-08-11
     License: MIT License - http://www.opensource.org/licenses/MIT
     
     Description:
@@ -34,7 +34,6 @@ class ItemRanks {
     class isRadio                   {};
     class openItemRanksDialog       {};
     class refreshArsenal            {};
-    class removeItemFromRank        {};
     class saveRankItemsClient       {};
     class saveRankItemsServer       {};
 }

--- a/Missionframework/modules/arsenal/fnc/fn_getPlayerAllowedItems.sqf
+++ b/Missionframework/modules/arsenal/fnc/fn_getPlayerAllowedItems.sqf
@@ -2,7 +2,7 @@
     File: fn_getPlayerAllowedItems.sqf
     Author: ColinM - https://github.com/ColinM9991/KP-Liberation
     Date: 2022-08-09
-    Last Update: 2022-08-09
+    Last Update: 2022-08-10
     License: MIT License - http://www.opensource.org/licenses/MIT
     
     Description:
@@ -27,5 +27,5 @@ if (isNil "TVG_playerAllowedArsenalItems") then {TVG_playerAllowedArsenalItems =
 
 private _rankRestrictions = [] call TVG_fnc_getRankRestrictedItems;
 
-TVG_playerAllowedArsenalItems = TVG_ranksArsenalItems select { !(_x in _rankRestrictions) };
+TVG_playerAllowedArsenalItems = TVG_playerArsenalItems select { !(_x in _rankRestrictions) };
 TVG_playerAllowedArsenalItems

--- a/Missionframework/modules/arsenal/fnc/fn_getRankRestrictedItems.sqf
+++ b/Missionframework/modules/arsenal/fnc/fn_getRankRestrictedItems.sqf
@@ -2,24 +2,19 @@
     File: fn_getRankRestrictedItems.sqf
     Author: ColinM - https://github.com/ColinM9991/KP-Liberation
     Date: 2022-08-08
-    Last Update: 2022-08-09
+    Last Update: 2022-08-11
     License: MIT License - http://www.opensource.org/licenses/MIT
     
     Description:
         Retrieves the arsenal items that a user is unable to use due to higher rank restrictions.
     
     Parameter(s):
-        _rank - The player rank [NUMBER, defaults to the current player rank]
     
     Returns:
         Array of restricted items
 */
-params[
-    ["_rank", -1, [-1]]
-];
 
-if(_rank isEqualTo -1) then { _rank = [] call KPR_fnc_getRank; };
-
+private _rank = [] call KPR_fnc_getRank;
 private _restrictedItems = [];
 
 {

--- a/Missionframework/modules/arsenal/fnc/fn_initRankRestrictions.sqf
+++ b/Missionframework/modules/arsenal/fnc/fn_initRankRestrictions.sqf
@@ -6,23 +6,48 @@
     License: MIT License - http://www.opensource.org/licenses/MIT
     
     Description:
-        No description added yet.
+        Initializes the rank restrictions functionality.
+        Adds the relevant event handlers to ensure the players gear is updated when they're promoted/demoted, and to ensure gear is removed from the player.
     
-    Parameter(s):
-        _localVariable - Description [DATATYPE, defaults to DEFAULTVALUE]
-    
+Parameter(s):
+    _allItems       - All of the items that will, or should be available to all players excluding any class restrictions.                                                                               [ARRAY, defaults to []]
+    _arsenalItems   - The items that will be added to a players arsenal. Separate from _allItems since a players items could be further restricted based on their current class (AT, Medic, Infantry)   [ARRAY, defaults to []]
+    _arsenalStore   - The object that the arsenal should be attached to. This can be a physical box or it can be the missionNamespace to attach it to all arsenal boxes or inits.                       [Namespace or Object, defaults to missionNamespace]
+    _useAceArsenal  - Whether or not the ACE arsenal functions should be used.                                                                                                                          [BOOLEAN, defaults to true]
+
     Returns:
         NONE
 */
 params[
+    ["_allItems", [], [[]]],
     ["_arsenalItems", [], [[]]],
+    ["_arsenalStore", missionNamespace, [missionNamespace, objNull]],
     ["_useAceArsenal", true, [true]]
 ];
 
-if (!isDedicated && hasInterface) then {
-    TVG_ranksAceArsenal = _useAceArsenal;
-    TVG_ranksArsenalItems = _arsenalItems;
+// Valid data hasn't been supplied, nothing to do.
+if(_allItems isEqualTo [] && _arsenalItems isEqualTo []) exitWith {};
 
+if (!isDedicated && hasInterface) then {
+
+    // If _arsenalItems hasn't been supplied, assume there are no class restrictions and use the full arsenal list.
+    if(_arsenalItems isEqualTo []) then {
+        _arsenalItems = _allItems;
+    };
+
+    // TODO: Test the implication of using missionNamespace with ACE Arsenal
+    if(_useAceArsenal && _arsenalStore isEqualTo missionNamespace) then {
+        _arsenalStore = player;
+    };
+
+    // Assign global variables that are scoped the player
+    // Ideally these would be handled on the server but some of them can be quite large, particularly the arrays.
+    TVG_ranksAceArsenal = _useAceArsenal;
+    TVG_ranksArsenalItems = _allItems;
+    TVG_playerArsenalItems = _arsenalItems;
+    TVG_arsenalStore = _arsenalStore;
+
+    // Populate the arsenal
     [] call TVG_fnc_refreshArsenal;
 
     // Gear Validation Event Handlers
@@ -49,8 +74,6 @@ if (!isDedicated && hasInterface) then {
         [] call TVG_fnc_refreshArsenal;
     }] call CBA_fnc_addEventHandler;
     
-    TVG_ranksArsenalInitialized = true;
-    
     // ACE Action for Admins
     _action = [
         "KPR_ArsenalManage", 
@@ -60,7 +83,7 @@ if (!isDedicated && hasInterface) then {
             [] call TVG_fnc_openItemRanksDialog;
         },
         {
-            KPR_isAdmin && TVG_ranksArsenalInitialized
+            KPR_isAdmin
         }] call ace_interact_menu_fnc_createAction;
     
     [(typeOf player), 1, ["ACE_SelfActions", "KPR_Admin"], _action] call ace_interact_menu_fnc_addActionToClass;  

--- a/Missionframework/modules/arsenal/fnc/fn_initRankRestrictions.sqf
+++ b/Missionframework/modules/arsenal/fnc/fn_initRankRestrictions.sqf
@@ -2,7 +2,7 @@
     File: fn_initRankRestrictions.sqf
     Author: ColinM - https://github.com/ColinM9991/KP-Liberation
     Date: 2022-08-09
-    Last Update: 2022-08-10
+    Last Update: 2022-08-11
     License: MIT License - http://www.opensource.org/licenses/MIT
     
     Description:
@@ -20,9 +20,9 @@ Parameter(s):
 */
 params[
     ["_allItems", [], [[]]],
+    ["_useAceArsenal", true, [true]],
     ["_arsenalItems", [], [[]]],
-    ["_arsenalStore", missionNamespace, [missionNamespace, objNull]],
-    ["_useAceArsenal", true, [true]]
+    ["_arsenalStore", missionNamespace, [missionNamespace, objNull]]
 ];
 
 // Valid data hasn't been supplied, nothing to do.

--- a/Missionframework/modules/arsenal/fnc/fn_refreshArsenal.sqf
+++ b/Missionframework/modules/arsenal/fnc/fn_refreshArsenal.sqf
@@ -2,7 +2,7 @@
     File: fn_refreshArsenal.sqf
     Author: ColinM - https://github.com/ColinM9991/KP-Liberation
     Date: 2022-08-08
-    Last Update: 2022-08-09
+    Last Update: 2022-08-10
     License: MIT License - http://www.opensource.org/licenses/MIT
     
     Description:
@@ -15,21 +15,21 @@
         NONE
 */
 if (TVG_ranksAceArsenal) then {
-    [player, true, false] call ace_arsenal_fnc_removeVirtualItems;
+    [TVG_arsenalStore, true, false] call ace_arsenal_fnc_removeVirtualItems;
 } else {
-    [missionNamespace, true] call BIS_fnc_removeVirtualWeaponCargo;
-    [missionNamespace, true] call BIS_fnc_removeVirtualMagazineCargo;
-    [missionNamespace, true] call BIS_fnc_removeVirtualItemCargo;
-    [missionNamespace, true] call BIS_fnc_removeVirtualBackpackCargo;
+    [TVG_arsenalStore, true] call BIS_fnc_removeVirtualWeaponCargo;
+    [TVG_arsenalStore, true] call BIS_fnc_removeVirtualMagazineCargo;
+    [TVG_arsenalStore, true] call BIS_fnc_removeVirtualItemCargo;
+    [TVG_arsenalStore, true] call BIS_fnc_removeVirtualBackpackCargo;
 };
 
 private _allowedItems = [true] call TVG_fnc_getPlayerAllowedItems;
 
 if (TVG_ranksAceArsenal) then {
-    [player, _allowedItems, false] call ace_arsenal_fnc_addVirtualItems;
+    [TVG_arsenalStore, _allowedItems, false] call ace_arsenal_fnc_addVirtualItems;
 } else {
-    [missionNamespace, _allowedItems] call BIS_fnc_addVirtualWeaponCargo;
-    [missionNamespace, _allowedItems] call BIS_fnc_addVirtualMagazineCargo;
-    [missionNamespace, _allowedItems] call BIS_fnc_addVirtualItemCargo;
-    [missionNamespace, _allowedItems] call BIS_fnc_addVirtualBackpackCargo;
+    [TVG_arsenalStore, _allowedItems] call BIS_fnc_addVirtualWeaponCargo;
+    [TVG_arsenalStore, _allowedItems] call BIS_fnc_addVirtualMagazineCargo;
+    [TVG_arsenalStore, _allowedItems] call BIS_fnc_addVirtualItemCargo;
+    [TVG_arsenalStore, _allowedItems] call BIS_fnc_addVirtualBackpackCargo;
 };

--- a/Missionframework/modules/arsenal/ui/ItemRanksDialog.hpp
+++ b/Missionframework/modules/arsenal/ui/ItemRanksDialog.hpp
@@ -114,6 +114,7 @@ class ItemRanksDialog {
             y = STARTING_POS_BUTTON;
             w = 0.0498837 * safezoneW;
             h = 0.022 * safezoneH;
+            onButtonClick = "closeDialog 2;";
         };
     }
 }

--- a/Missionframework/scripts/client/build/fnc/fn_buildItem.sqf
+++ b/Missionframework/scripts/client/build/fnc/fn_buildItem.sqf
@@ -2,7 +2,7 @@
     File: fn_buildItem.sqf
     Author: ColinM - https://github.com/ColinM9991/KP-Liberation
     Date: 2022-08-01
-    Last Update: 2022-08-02
+    Last Update: 2022-08-11
     License: MIT License - http://www.opensource.org/licenses/MIT
     
     Description:
@@ -31,6 +31,8 @@ private _direction = getDir _previewVehicle;
 
 deleteVehicle _previewVehicle;
 
+uiSleep 0.05;
+
 _vehicle = _classname createVehicle _position;
 _vehicle allowDamage false;
 _vehicle setDir _direction;
@@ -43,8 +45,6 @@ if ((toLower (typeOf _vehicle)) in KPLIB_b_static_classes) then {
 
 if (!build_vector && {_buildType isEqualTo BUILD_TYPE_BUILDING || _buildType isEqualTo BUILD_TYPE_FOB || (toLower _className) in KPLIB_storageBuildings || _classname isEqualTo KP_liberation_recycle_building || _classname isEqualTo KP_liberation_air_vehicle_building}) then {
     _vehicle setVectorUp [0,0,1];
-} else {
-    _vehicle setVectorUp surfaceNormal position _vehicle;
 };
 
 if(_buildType isEqualTo BUILD_TYPE_SECTOR) then {

--- a/Missionframework/scripts/client/build/fnc/fn_build_postInit.sqf
+++ b/Missionframework/scripts/client/build/fnc/fn_build_postInit.sqf
@@ -2,7 +2,7 @@
     File: fn_postInit.sqf
     Author: ColinM - https://github.com/ColinM9991/KP-Liberation
     Date: 2022-08-01
-    Last Update: 2022-08-02
+    Last Update: 2022-08-11
     License: MIT License - http://www.opensource.org/licenses/MIT
     
     Description:
@@ -19,6 +19,7 @@ KPLIB_isBuilding = false;
 KPLIB_buildInvalid = false;
 KPLIB_hasCancelledBuild = false;
 KPLIB_buildingInProgress = false;
+KPLIB_repeatBuild = false;
 KPLIB_buildType = -1;
 KPLIB_buildPreview = objNull;
 

--- a/Missionframework/scripts/client/build/fnc/fn_handleBuild.sqf
+++ b/Missionframework/scripts/client/build/fnc/fn_handleBuild.sqf
@@ -2,7 +2,7 @@
     File: fn_handleBuild.sqf
     Author: ColinM - https://github.com/ColinM9991/KP-Liberation
     Date: 2022-08-01
-    Last Update: 2022-08-02
+    Last Update: 2022-08-11
     License: MIT License - http://www.opensource.org/licenses/MIT
     
     Description:
@@ -86,8 +86,8 @@ while { KPLIB_buildingInProgress } do {
     KPLIB_isBuilding = true;
     while { KPLIB_isBuilding && {!KPLIB_hasCancelledBuild} && {alive player} } do {
         private _playerDirection = getDir player;
-        private _trueDir = 90 - _playerDirection;
         private _truePos = [];
+        private _trueDir = 90 - _playerDirection;
         if ((toLower (typeOf _vehicle)) in KPLIB_b_static_classes) then {
             _truePos = [((getposATL player) select 0) + (build_distance * (cos _trueDir)), ((getposATL player) select 1) + (build_distance * (sin _trueDir)),((getposATL player) select 2)];
         } else {
@@ -129,9 +129,18 @@ while { KPLIB_buildingInProgress } do {
             };
         };
 
-        uiSleep 0.01;
+        uiSleep 0.04;
     };
     
+    if (!KPLIB_repeatBuild) then {
+        build_rotation = 0;
+        build_elevation = 0;
+        build_distance = 0;
+        build_vector = false;
+    } else {
+        KPLIB_repeatBuild = false;
+    };
+
     if (KPLIB_hasCancelledBuild) exitWith {
         deleteVehicle _vehicle;
         KPLIB_hasCancelledBuild = false;

--- a/Missionframework/scripts/client/build/fnc/fn_handleBuildPlacement.sqf
+++ b/Missionframework/scripts/client/build/fnc/fn_handleBuildPlacement.sqf
@@ -2,7 +2,7 @@
     File: fn_handleBuildPlacement.sqf
     Author: ColinM https://github.com/ColinM9991/KP-Liberation
     Date: 2022-07-20
-    Last Update: 2022-08-02
+    Last Update: 2022-08-11
     License: MIT License - http://www.opensource.org/licenses/MIT
 
     Description:
@@ -19,12 +19,8 @@ params[
 if(_shouldRepeat && _buildType isEqualTo 6) then {
     KPLIB_isBuilding = false;
     KPLIB_hasCancelledBuild = false;
-} else {
-    build_rotation = 0;
-    build_elevation = 0;
-    build_distance = 0;
-    build_vector = false;
-    
+    KPLIB_repeatBuild = true;
+} else {    
     KPLIB_isBuilding = false;
     KPLIB_hasCancelledBuild = false;
     KPLIB_buildingInProgress = false;


### PR DESCRIPTION
Includes some bugfixes and updates.

Arsenal Ranks:
* Cancel button missing an action
* Allow consumers to pass a global arsenal list, and a player specific arsenal list, to the rank system.
* Allow consumers to specify the object or namespace that the arsenal pertains to

Build System:
* Fix the Vector mode
* Add a delay between deleting the preview object and spawning the physical object